### PR TITLE
fix: add missing GroupDAOContext

### DIFF
--- a/src/GroupDAOContext.jsx
+++ b/src/GroupDAOContext.jsx
@@ -1,0 +1,6 @@
+import { createContext, useContext } from 'react';
+
+export const GroupDAOContext = createContext(null);
+
+export const useGroupDAO = () => useContext(GroupDAOContext);
+


### PR DESCRIPTION
## Summary
- add GroupDAOContext to provide react context wrapper

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69899bd0483338257e31d04afb31e