### PR TITLE
fix: replace react-hot-toast with react-toastify

### DIFF
--- a/src/GroupList.jsx
+++ b/src/GroupList.jsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { useGroupDAO } from "./App";
 import { Users, ChevronDown, ChevronRight, Loader2, Eye } from "lucide-react";
-import { toast } from "react-hot-toast";
+import { toast } from "react-toastify";
 
 const Card = ({ title, icon, children, actions, className = "" }) => (
   <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white"}`}>


### PR DESCRIPTION
## Summary
- replace missing `react-hot-toast` import with `react-toastify` in `GroupList`

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a69e62edac833381c3aa2dd1994992