### PR TITLE
fix: corregir importaciones de useGroupDAO

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { useGroupDAO } from "./App";
+import { useGroupDAO } from "./GroupDAOContext";
 import { useForm } from "react-hook-form";
 import { ethers } from "ethers";
 import { Upload, UserCog, Users, ListFilter, Loader2, Link as LinkIcon, Settings, ChevronRight, ChevronDown, Shield, Pause, Play } from "lucide-react";

--- a/src/GroupList.jsx
+++ b/src/GroupList.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useGroupDAO } from "./App";
+import { useGroupDAO } from "./GroupDAOContext";
 import { Users, ChevronDown, ChevronRight, Loader2, Eye } from "lucide-react";
 import { toast } from "react-toastify";
 

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo } from "react";
-import { useGroupDAO } from "./App";
+import { useGroupDAO } from "./GroupDAOContext";
 import { Shield, ThumbsUp, ThumbsDown, CircleSlash, Loader2 } from "lucide-react";
 import { toast } from "react-toastify";
 import { format } from "date-fns";

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from "react";
-import { useGroupDAO } from "./App";
+import { useGroupDAO } from "./GroupDAOContext";
 import { ListFilter, Loader2 } from "lucide-react";
 import { toast } from "react-toastify"; // Importar toast
 


### PR DESCRIPTION
## Summary
- importa `useGroupDAO` desde `GroupDAOContext`
- evita error de exportación inexistente al cargar componentes

## Testing
- `npm test` (falta script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6a0436a6083339dd98f8c6020740d