### PR TITLE
Fix group member refresh and proposal dates

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -4,7 +4,6 @@ import { useForm } from "react-hook-form";
 import { ethers } from "ethers";
 import { Upload, UserCog, Users, ListFilter, Loader2, Link as LinkIcon, Settings, ChevronRight, ChevronDown, Shield, Pause, Play } from "lucide-react";
 import { toast } from "react-toastify";
-import { startOfDay, endOfDay } from "date-fns";
 import RosterTable from "./RosterTable";
 
 // Función auxiliar para verificar si una función existe en el contrato
@@ -103,8 +102,8 @@ export default function AdminPanel() {
     if (!isAdmin) return toast.error("Solo admins pueden crear propuestas");
     const { title, description, groupId, startDate, endDate } = data;
     if (!groupId || !groups.find((g) => g.id === Number(groupId))) return toast.error("Grupo inválido");
-    const startSec = Math.floor(startOfDay(new Date(startDate)).getTime() / 1000);
-    const endSec = Math.floor(endOfDay(new Date(endDate)).getTime() / 1000);
+    const startSec = Math.floor(new Date(`${startDate}T00:00:00`).getTime() / 1000);
+    const endSec = Math.floor(new Date(`${endDate}T23:59:59`).getTime() / 1000);
     await run("createProposal", async () => {
       const hasCP2 = hasFn(contract, "createProposal2");
       const tx = await withGas(

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1309,7 +1309,7 @@ const nowSec = () => Math.floor(Date.now() / 1000);
 const withGas = async (estimatePromise, txPromiseFactory) => {
   try {
     const est = await estimatePromise;
-    const gasLimit = (est * 120n) / 100n; // +20%
+    const gasLimit = (est * 110n) / 100n; // +10%
     return await txPromiseFactory({ gasLimit });
   } catch {
     return await txPromiseFactory({});

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -20,6 +20,7 @@ export default function RosterTable() {
     fetchAll,
     demoGroups,
     withGas, // Añadido del contexto
+    setGroupMembersCache,
   } = useGroupDAO();
 
   const actionBulkAddToGroup = async (addrs, gid) => {
@@ -31,6 +32,14 @@ export default function RosterTable() {
       );
       await tx.wait();
       setRosterSelection({});
+      try {
+        const list = await (contract.getGroupMembersSlice
+          ? contract.getGroupMembersSlice(Number(gid), 0, 1000)
+          : contract.getGroupMembers(Number(gid)));
+        setGroupMembersCache((prev) => ({ ...prev, [gid]: list }));
+      } catch {
+        // ignore errors loading members
+      }
       await fetchAll();
     });
   };


### PR DESCRIPTION
## Summary
- Refresh group member list after bulk additions
- Parse proposal dates in local time to avoid one-day offset
- Tweak gas estimation helper to lower excess gas limits

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b0fcf5308333b650540a6101fb21