### PR TITLE
fix: defer user registration visibility

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -191,7 +191,7 @@ export default function AdminPanel() {
 
   return (
     <>
-      {!registered && contract && (
+      {registered === false && contract && (
         <div className="mb-4 p-4 border rounded-xl bg-white shadow-sm">
           <h3 className="text-lg font-semibold mb-2">Registro de Usuario</h3>
           <p className="text-sm text-gray-600 mb-4">Ingresa tus datos para asociarlos a tu billetera la primera vez.</p>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1322,7 +1322,7 @@ export default function App() {
   const [contract, setContract] = useState(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
-  const [registered, setRegistered] = useState(false);
+  const [registered, setRegistered] = useState(null);
   const [error, setError] = useState("");
   const [demo, setDemo] = useState(false);
   const [busy, setBusy] = useState({});
@@ -1539,7 +1539,7 @@ export default function App() {
       setContract(null);
       setIsAdmin(false);
       setIsOwner(false);
-      setRegistered(false);
+      setRegistered(null);
       setGroups([]);
       setMyGroupIds([]);
       setProposals([]);


### PR DESCRIPTION
## Summary
- Hide registration form until the user's registration status is known
- Reset registration state on disconnect

## Testing
- ⚠️ `npm test` *(missing script: test)*
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6b247a28c83339d405e3bc67263b2