### PR TITLE
feat: mejorar interfaz de grupos

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1361,7 +1361,13 @@ export default function App() {
 
   const rosterIndex = useMemo(() => {
     const m = new Map();
-    for (const r of roster) if (r.address) m.set(r.address.toLowerCase(), { name: r.name || r.nombre || "", dni: r.dni || r.DNI || "" });
+    for (const r of roster) if (r.address) {
+      m.set(r.address.toLowerCase(), {
+        name: r.name || r.nombre || "",
+        surname: r.surname || r.apellido || "",
+        dni: r.dni || r.DNI || ""
+      });
+    }
     return m;
   }, [roster]);
 
@@ -1622,13 +1628,23 @@ export default function App() {
     (csvRows || []).forEach(r => {
       const addr = (r.address || r.wallet || "").trim().toLowerCase();
       if (!addr || !ethers.isAddress(addr)) return;
-      mapCSV.set(addr, { name: r.name || r.nombre || "", dni: r.dni || r.DNI || "", address: addr });
+      mapCSV.set(addr, {
+        name: r.name || r.nombre || "",
+        surname: r.surname || r.apellido || "",
+        dni: r.dni || r.DNI || "",
+        address: addr
+      });
     });
 
     const rows = [];
     (baseAddrList || []).forEach(addr => {
       const found = mapCSV.get(addr.toLowerCase());
-      rows.push({ address: addr, name: found?.name || "", dni: found?.dni || "" });
+      rows.push({
+        address: addr,
+        name: found?.name || "",
+        surname: found?.surname || "",
+        dni: found?.dni || ""
+      });
     });
 
     setRoster(rows.sort((a, b) => (a.name || "").localeCompare(b.name || "")));
@@ -1646,6 +1662,7 @@ export default function App() {
       complete: (res) => {
         const rows = (res.data || []).map(r => ({
           name: r.name || r.nombre || "",
+          surname: r.surname || r.apellido || "",
           dni: r.dni || r.DNI || "",
           address: (r.address || r.wallet || "").trim()
         }));

--- a/src/GroupList.jsx
+++ b/src/GroupList.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useGroupDAO } from "./GroupDAOContext";
-import { Users, ChevronDown, ChevronRight, Loader2, Eye } from "lucide-react";
+import { Users, ChevronDown, ChevronRight, Loader2, X } from "lucide-react";
 import { toast } from "react-toastify";
 
 const Card = ({ title, icon, children, actions, className = "" }) => (
@@ -16,16 +16,62 @@ const Card = ({ title, icon, children, actions, className = "" }) => (
   </div>
 );
 
-function parseRemoteCSV(file) {
-  // Placeholder: implement CSV parsing logic here
-  // For now, just show a toast
-  toast.success(`Archivo CSV "${file.name}" cargado (implementa parseo).`);
-}
+const MembersModal = ({ groupId, onClose }) => {
+  const { demo, groups, demoGroups, groupMembersCache, rosterIndex } = useGroupDAO();
+  const g = (demo ? demoGroups : groups).find(x => x.id === groupId) || { name: `Grupo ${groupId}` };
+  const addresses = demo
+    ? Array.from({ length: demoGroups.find(x => x.id === groupId)?.memberCount || 0 }).map((_, i) => `0xDEMO${i.toString().padStart(2, '0')}`)
+    : (groupMembersCache[groupId] || []);
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" role="dialog" aria-modal="true">
+      <div className="bg-white rounded-xl p-4 w-full max-w-lg max-h-[80vh] flex flex-col">
+        <div className="flex items-center justify-between mb-2">
+          <h2 className="text-lg font-semibold">Integrantes de {g.name}</h2>
+          <button onClick={onClose} aria-label="Cerrar" className="text-gray-500 hover:text-gray-700">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+        <div className="overflow-auto mt-2">
+          {(!demo && !groupMembersCache[groupId]) ? (
+            <div className="text-gray-500 flex items-center gap-2 justify-center p-4">
+              <Loader2 className="w-4 h-4 animate-spin" /> Cargando integrantes…
+            </div>
+          ) : (
+            <table className="w-full text-sm">
+              <thead className="bg-gray-100 sticky top-0">
+                <tr>
+                  <th className="p-2 text-left">Nombre</th>
+                  <th className="p-2 text-left">Apellido</th>
+                  <th className="p-2 text-left">DNI</th>
+                  <th className="p-2 text-left">Address</th>
+                </tr>
+              </thead>
+              <tbody>
+                {addresses.map((addr, i) => {
+                  const meta = rosterIndex.get((addr || "").toLowerCase()) || {};
+                  return (
+                    <tr key={i} className="border-t">
+                      <td className="p-2">{meta.name || ""}</td>
+                      <td className="p-2">{meta.surname || ""}</td>
+                      <td className="p-2">{meta.dni || ""}</td>
+                      <td className="p-2 font-mono">{addr}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default function GroupList() {
   const {
     contract, demo, groups, myGroupIds, groupMembersCache, setGroupMembersCache,
-    openMembersGroup, setOpenMembersGroup, loadingGroups, rosterIndex, demoGroups
+    openMembersGroup, setOpenMembersGroup, loadingGroups, demoGroups
   } = useGroupDAO();
 
   const toggleMembers = async (groupId) => {
@@ -45,58 +91,35 @@ export default function GroupList() {
     }
   };
 
-  const displayAlias = (addr) => {
-    const a = (addr || "").toLowerCase();
-    const meta = rosterIndex.get(a);
-    if (meta && (meta.name || meta.dni)) return `${meta.name || ""}${meta.dni ? ` (DNI ${meta.dni})` : ""} – ${addr}`;
-    return addr;
-  };
-
   return (
-    <Card
-      title="Mis grupos"
-      icon={<Users className="w-5 h-5" />}
-      actions={loadingGroups && <div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="w-4 h-4 animate-spin" /> Actualizando grupos…</div>}
-    >
-      <div className="flex items-center gap-2 mb-2 text-xs text-gray-500">
-        <Eye className="w-3 h-3" /> Podés cargar un CSV para ver alias locales.
-        <input
-          type="file"
-          accept=".csv"
-          onChange={(e) => e.target.files?.[0] && parseRemoteCSV(e.target.files[0])}
-          aria-label="Cargar CSV para alias"
-        />
-      </div>
-      <div className="flex flex-wrap gap-2">
-        {(demo ? demoGroups.map(g => g.id) : myGroupIds).map(id => {
-          const g = (demo ? demoGroups : groups).find(x => x.id === id) || { name: `Grupo ${id}`, memberCount: 0 };
-          const open = openMembersGroup === id;
-          return (
-            <div key={id}>
+    <>
+      <Card
+        title="Mis grupos"
+        icon={<Users className="w-5 h-5" />}
+        actions={loadingGroups && <div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="w-4 h-4 animate-spin" /> Actualizando grupos…</div>}
+      >
+        <div className="flex flex-wrap gap-2">
+          {(demo ? demoGroups.map(g => g.id) : myGroupIds).map(id => {
+            const g = (demo ? demoGroups : groups).find(x => x.id === id) || { name: `Grupo ${id}`, memberCount: 0 };
+            const open = openMembersGroup === id;
+            return (
               <button
+                key={id}
                 onClick={() => toggleMembers(id)}
-                className={`mr-2 mb-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
-                aria-label={`Toggle miembros del grupo ${g.name}`}
+                className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
+                aria-label={`Ver miembros del grupo ${g.name}`}
               >
                 {open ? <ChevronDown className="w-3 h-3"/> : <ChevronRight className="w-3 h-3"/>}
                 {id} – {g.name}
               </button>
-              {open && (
-                <div className="mt-1 mb-3 ml-2 p-2 border rounded-xl bg-gray-50 max-h-40 overflow-auto text-xs">
-                  <div className="mb-1 text-gray-600">Integrantes ({demo ? (demoGroups.find(x => x.id === id)?.memberCount || 0) : (groupMembersCache[id]?.length ?? g.memberCount)}):</div>
-                  <ul className="font-mono space-y-1">
-                    {(demo ? Array.from({length: (demoGroups.find(x => x.id === id)?.memberCount || 0)}).map((_, i) => `0xDEMO${i.toString().padStart(2, '0')}`) : (groupMembersCache[id] || [])).map((addr, i) => (
-                      <li key={i}>{displayAlias(addr)}</li>
-                    ))}
-                    {!demo && !groupMembersCache[id] && <div className="text-gray-500 flex items-center gap-2"><Loader2 className="w-3 h-3 animate-spin"/> Cargando integrantes…</div>}
-                  </ul>
-                </div>
-              )}
-            </div>
-          );
-        })}
-        {(!demo && !myGroupIds.length) && <div className="text-sm text-gray-500">No integrás ningún grupo todavía.</div>}
-      </div>
-    </Card>
+            );
+          })}
+          {(!demo && !myGroupIds.length) && <div className="text-sm text-gray-500">No integrás ningún grupo todavía.</div>}
+        </div>
+      </Card>
+      {openMembersGroup && (
+        <MembersModal groupId={openMembersGroup} onClose={() => setOpenMembersGroup(null)} />
+      )}
+    </>
   );
 }

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -48,6 +48,7 @@ export default function RosterTable() {
   const filteredRoster = useMemo(() => {
     return roster.filter((r) =>
       (r.name || r.nombre || "").toLowerCase().includes(rosterFilter.toLowerCase()) ||
+      (r.surname || r.apellido || "").toLowerCase().includes(rosterFilter.toLowerCase()) ||
       (r.dni || r.DNI || "").toLowerCase().includes(rosterFilter.toLowerCase()) ||
       (r.address || "").toLowerCase().includes(rosterFilter.toLowerCase())
     );
@@ -61,7 +62,7 @@ export default function RosterTable() {
           <ListFilter className="w-4 h-4" />
           <input
             className="border rounded-xl p-2 w-full"
-            placeholder="Filtrar por nombre, DNI o address…"
+            placeholder="Filtrar por nombre, apellido, DNI o address…"
             value={rosterFilter}
             onChange={(e) => setRosterFilter(e.target.value)}
             aria-label="Filtrar roster"
@@ -102,6 +103,7 @@ export default function RosterTable() {
             <tr>
               <th className="p-2 text-left">✓</th>
               <th className="p-2 text-left">Nombre</th>
+              <th className="p-2 text-left">Apellido</th>
               <th className="p-2 text-left">DNI</th>
               <th className="p-2 text-left">Address</th>
             </tr>
@@ -120,13 +122,14 @@ export default function RosterTable() {
                   />
                 </td>
                 <td className="p-2">{r.name || r.nombre || ""}</td>
+                <td className="p-2">{r.surname || r.apellido || ""}</td>
                 <td className="p-2">{r.dni || r.DNI || ""}</td>
                 <td className="p-2 font-mono">{r.address}</td>
               </tr>
             ))}
             {!filteredRoster.length && (
               <tr>
-                <td colSpan={4} className="p-3 text-center text-gray-500">
+                <td colSpan={5} className="p-3 text-center text-gray-500">
                   Sin datos. Cargá un CSV/URL o asegurate de tener grupos con integrantes.
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- Reemplaza el despliegue de integrantes por un modal con tabla scrolleable.
- Amplía y estiliza las etiquetas de grupos y elimina la carga local de CSV.
- Añade soporte de apellido en el roster y lo muestra en tablas y popups.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a75d5ec19c8333a570571c0f96d55e