### PR TITLE
Remove redundant details toggle for finalized votes

### DIFF
--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -296,26 +296,6 @@ export default function ProposalList() {
                   <span className="text-gray-600">{p.noVotaron}</span>
                 </div>
               </div>
-              <button
-                className="text-xs text-gray-500 mt-2"
-                onClick={() => loadBreakdown(p)}
-                aria-label={`Toggle detalles de votación ${p.title}`}
-              >
-                {breakdownOpen[p.id] ? "Ocultar detalles" : "Ver detalles"}
-              </button>
-              {breakdownOpen[p.id] && (
-                <div className="mt-2 text-xs">
-                  {breakdownLoading[p.id] ? (
-                    <div className="flex items-center gap-2"><Loader2 className="w-4 h-4 animate-spin" /> Cargando detalles…</div>
-                  ) : (
-                    <div>
-                      <div>A favor: {breakdownData[p.id]?.up?.length || 0}</div>
-                      <div>En contra: {breakdownData[p.id]?.down?.length || 0}</div>
-                      <div>Sin votar: {breakdownData[p.id]?.none?.length || 0}</div>
-                    </div>
-                  )}
-                </div>
-              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- Remove "Ver detalles" button from closed votes; results already displayed.

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a7855d2148833385a56b24e2c90be5