### PR TITLE
Add DNI hash verification to roster table

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1664,6 +1664,7 @@ export default function App() {
         name: r.name || r.nombre || "",
         surname: r.surname || r.apellido || "",
         dni: r.dni || r.DNI || "",
+        puesto: r.puesto || "",
         address: addr
       });
     });
@@ -1675,7 +1676,8 @@ export default function App() {
         address: addr,
         name: found?.name || "",
         surname: found?.surname || "",
-        dni: found?.dni || ""
+        dni: found?.dni || "",
+        puesto: found?.puesto || ""
       });
     });
 
@@ -1696,6 +1698,7 @@ export default function App() {
           name: r.name || r.nombre || "",
           surname: r.surname || r.apellido || "",
           dni: r.dni || r.DNI || "",
+          puesto: r.puesto || "",
           address: (r.address || r.wallet || "").trim()
         }));
         setCsvData(rows);

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from "react";
 import { useGroupDAO } from "./GroupDAOContext";
-import { ListFilter, Loader2 } from "lucide-react";
+import { ListFilter, Loader2, Check, X } from "lucide-react";
+import { ethers } from "ethers";
 import { toast } from "react-toastify"; // Importar toast
 
 export default function RosterTable() {
@@ -106,30 +107,40 @@ export default function RosterTable() {
               <th className="p-2 text-left">Apellido</th>
               <th className="p-2 text-left">DNI</th>
               <th className="p-2 text-left">Address</th>
+              <th className="p-2 text-left">Hash</th>
             </tr>
           </thead>
           <tbody>
-            {filteredRoster.map((r, idx) => (
-              <tr key={idx} className="border-t">
-                <td className="p-2">
-                  <input
-                    type="checkbox"
-                    checked={!!rosterSelection[r.address]}
-                    onChange={(e) =>
-                      setRosterSelection((s) => ({ ...s, [r.address]: e.target.checked }))
-                    }
-                    aria-label={`Seleccionar ${r.name || r.address}`}
-                  />
-                </td>
-                <td className="p-2">{r.name || r.nombre || ""}</td>
-                <td className="p-2">{r.surname || r.apellido || ""}</td>
-                <td className="p-2">{r.dni || r.DNI || ""}</td>
-                <td className="p-2 font-mono">{r.address}</td>
-              </tr>
-            ))}
+            {filteredRoster.map((r, idx) => {
+              const dni = r.dni || r.DNI || "";
+              const expected = r.puesto || "";
+              const hash = dni ? ethers.keccak256(ethers.toUtf8Bytes(dni)) : "";
+              const ok = expected && hash === expected;
+              return (
+                <tr key={idx} className="border-t">
+                  <td className="p-2">
+                    <input
+                      type="checkbox"
+                      checked={!!rosterSelection[r.address]}
+                      onChange={(e) =>
+                        setRosterSelection((s) => ({ ...s, [r.address]: e.target.checked }))
+                      }
+                      aria-label={`Seleccionar ${r.name || r.address}`}
+                    />
+                  </td>
+                  <td className="p-2">{r.name || r.nombre || ""}</td>
+                  <td className="p-2">{r.surname || r.apellido || ""}</td>
+                  <td className="p-2">{dni}</td>
+                  <td className="p-2 font-mono">{r.address}</td>
+                  <td className="p-2 text-center">
+                    {ok ? <Check className="w-4 h-4 text-green-600" /> : <X className="w-4 h-4 text-red-600" />}
+                  </td>
+                </tr>
+              );
+            })}
             {!filteredRoster.length && (
               <tr>
-                <td colSpan={5} className="p-3 text-center text-gray-500">
+                <td colSpan={6} className="p-3 text-center text-gray-500">
                   Sin datos. Cargá un CSV/URL o asegurate de tener grupos con integrantes.
                 </td>
               </tr>


### PR DESCRIPTION
## Summary
- include puesto field from CSV and propagate through roster data
- show DNI hash validation column with tick or cross in roster table

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a78cb0c3988333aff420fc9af8e1d0