### PR TITLE
feat: improve pause controls

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -29,6 +29,7 @@ export default function AdminPanel() {
     contract,
     isAdmin,
     isOwner,
+    paused,
     demo,
     groups,
     run,
@@ -301,21 +302,26 @@ export default function AdminPanel() {
               <div className="border rounded-xl p-3 bg-white">
                 <div className="flex items-center gap-2 mb-2 text-sm font-medium">
                   <Shield className="w-4 h-4" /> Control del contrato
+                  <span
+                    className={`ml-auto px-2 py-0.5 rounded-full text-xs ${paused ? "bg-red-100 text-red-600" : "bg-green-100 text-green-600"}`}
+                  >
+                    {paused ? "Pausado" : "Activo"}
+                  </span>
                 </div>
                 <div className="flex gap-2">
                   <button
-                    disabled={isBusy("pause")}
+                    disabled={isBusy("pause") || paused}
                     onClick={onPause}
-                    className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-red-50 hover:bg-red-100"
+                    className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-red-50 hover:bg-red-100 disabled:opacity-50"
                     aria-label="Pausar contrato"
                   >
                     {isBusy("pause") && <Loader2 className="w-4 h-4 animate-spin" />}
                     <Pause className="w-4 h-4" /> Pausar
                   </button>
                   <button
-                    disabled={isBusy("unpause")}
+                    disabled={isBusy("unpause") || !paused}
                     onClick={onUnpause}
-                    className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-green-50 hover:bg-green-100"
+                    className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-green-50 hover:bg-green-100 disabled:opacity-50"
                     aria-label="Despausar contrato"
                   >
                     {isBusy("unpause") && <Loader2 className="w-4 h-4 animate-spin" />}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1322,6 +1322,7 @@ export default function App() {
   const [contract, setContract] = useState(null);
   const [isAdmin, setIsAdmin] = useState(false);
   const [isOwner, setIsOwner] = useState(false);
+  const [paused, setPaused] = useState(false);
   const [registered, setRegistered] = useState(null);
   const [error, setError] = useState("");
   const [demo, setDemo] = useState(false);
@@ -1351,7 +1352,10 @@ export default function App() {
       await fn();
       toast.success(`Acción ${key} completada con éxito`);
     } catch (e) {
-      const msg = e?.shortMessage || e?.message || "Error en la acción";
+      let msg = e?.shortMessage || e?.message || "Error en la acción";
+      if (msg.toLowerCase().includes("paused")) {
+        msg = "El contrato está en pausa. Intenta nuevamente cuando esté activo.";
+      }
       toast.error(msg);
       setError(msg);
     } finally {
@@ -1470,6 +1474,8 @@ export default function App() {
       setIsAdmin(admin);
       const reg = await contract.isRegistered(account);
       setRegistered(reg);
+      const p = await contract.paused?.();
+      if (typeof p === "boolean") setPaused(p);
 
       const totalGroups = Number(await contract.groupCount());
       if (totalGroups > 100) throw new Error("Demasiados grupos, usa paginación");
@@ -1753,7 +1759,7 @@ export default function App() {
   // ------------------ Render ------------------
   return (
     <GroupDAOContext.Provider value={{
-      contract, account, isAdmin, isOwner, registered, demo, groups, myGroupIds, proposals,
+      contract, account, isAdmin, isOwner, paused, registered, demo, groups, myGroupIds, proposals,
       groupMembersCache, setGroupMembersCache, openMembersGroup, setOpenMembersGroup,
       admins, setAdmins, loadingGroups, loadingProposals, roster, rosterFilter, setRosterFilter,
       rosterSelection, setRosterSelection, targetGroupId, setTargetGroupId, rosterURL, setRosterURL,


### PR DESCRIPTION
## Summary
- show contract pause state and disable pause/unpause buttons accordingly
- surface paused status in context and friendly message when paused

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a79ea85f24833390b07e9e2caf1bd9