### PR TITLE
Handle Ethers call exceptions with friendly message

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1353,7 +1353,10 @@ export default function App() {
       toast.success(`Acción ${key} completada con éxito`);
     } catch (e) {
       let msg = e?.shortMessage || e?.message || "Error en la acción";
-      if (msg.toLowerCase().includes("paused")) {
+      const lower = msg.toLowerCase();
+      if (e?.code === "CALL_EXCEPTION" || lower.includes("missing revert data")) {
+        msg = "La llamada al contrato falló. Verificá que estés en la red correcta o reintentá más tarde.";
+      } else if (lower.includes("paused")) {
         msg = "El contrato está en pausa. Intenta nuevamente cuando esté activo.";
       }
       toast.error(msg);


### PR DESCRIPTION
## Summary
- Display a clearer toast when contract calls fail with a CALL_EXCEPTION
- Keep existing pause message for paused contracts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a87944a58083338eb77e63a2876827