### PR TITLE
Improve voting UI and gas estimates

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -175,7 +175,10 @@ export default function AdminPanel() {
 
   const onPause = async () => {
     await run("pause", async () => {
-      const tx = await contract.pause();
+      const tx = await withGas(
+        contract.pause.estimateGas(),
+        (opts) => contract.pause(opts)
+      );
       await tx.wait();
       await fetchAll();
     });
@@ -183,7 +186,10 @@ export default function AdminPanel() {
 
   const onUnpause = async () => {
     await run("unpause", async () => {
-      const tx = await contract.unpause();
+      const tx = await withGas(
+        contract.unpause.estimateGas(),
+        (opts) => contract.unpause(opts)
+      );
       await tx.wait();
       await fetchAll();
     });
@@ -516,7 +522,10 @@ export default function AdminPanel() {
                     disabled={isBusy("saveRosterURL")}
                     onClick={() =>
                       run("saveRosterURL", async () => {
-                        const tx = await contract.setRosterURI(rosterURL);
+                        const tx = await withGas(
+                          contract.setRosterURI.estimateGas(rosterURL),
+                          (opts) => contract.setRosterURI(rosterURL, opts)
+                        );
                         await tx.wait();
                         localStorage.setItem("groupdao.rosterURL", rosterURL);
                         setRosterURL(rosterURL);

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -191,6 +191,7 @@ export default function ProposalList() {
                   return (
                     <span
                       key={gid}
+                      title="Grupos que intervienen en esta votación"
                       className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
                     >
                       {g.id} – {g.name}
@@ -202,7 +203,7 @@ export default function ProposalList() {
                 <summary className="cursor-pointer select-none flex items-start justify-between gap-2">
                   <div className="font-semibold text-base leading-tight">#{p.id} · {p.title || p.text}</div>
                 </summary>
-                <div className="mt-2 text-xs text-gray-500">{fmtDate(p.startTime)} → {fmtDate(p.endTime)}</div>
+                <div className="mt-2 text-xs text-gray-500">Período para votación: {fmtDate(p.startTime)} → {fmtDate(p.endTime)}</div>
                 {p.description && <div className="mt-1 text-sm whitespace-pre-wrap">{p.description}</div>}
               </details>
               <div className="flex flex-wrap items-center gap-3 mt-3">
@@ -299,6 +300,7 @@ export default function ProposalList() {
                   return (
                     <span
                       key={gid}
+                      title="Grupos que intervienen en esta votación"
                       className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
                     >
                       {g.id} – {g.name}
@@ -310,7 +312,7 @@ export default function ProposalList() {
                 <summary className="cursor-pointer select-none flex items-start justify-between gap-2">
                   <div className="font-semibold text-base leading-tight">#{p.id} · {p.title || p.text}</div>
                 </summary>
-                <div className="mt-2 text-xs text-gray-500">{fmtDate(p.startTime)} → {fmtDate(p.endTime)}</div>
+                <div className="mt-2 text-xs text-gray-500">Período para votación: {fmtDate(p.startTime)} → {fmtDate(p.endTime)}</div>
                 {p.description && <div className="mt-1 text-sm whitespace-pre-wrap">{p.description}</div>}
               </details>
               <div className="mt-3 flex items-center justify-end gap-4 text-sm">


### PR DESCRIPTION
## Summary
- Show tooltip for groups in voting and label the voting period
- Estimate gas for pause, unpause, and roster URL updates to reduce manual adjustments

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8b3ce61748333b2d177d8ebd7f1e7