### PR TITLE
feat: improve UX with dark mode and accessibility

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -5,24 +5,12 @@ import { ethers } from "ethers";
 import { UserCog, Users, ListFilter, Loader2, Link as LinkIcon, Settings, ChevronRight, ChevronDown, Shield, Pause, Play } from "lucide-react";
 import { toast } from "react-toastify";
 import RosterTable from "./RosterTable";
+import Card from "./components/Card";
 
 // Función auxiliar para verificar si una función existe en el contrato
 const hasFn = (contract, fnName) => {
   return contract && contract[fnName] && typeof contract[fnName] === "function";
 };
-
-const Card = ({ title, icon, children, actions, className = "" }) => (
-  <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white"}`}>
-    <div className="flex items-center justify-between mb-3">
-      <div className="flex items-center gap-2 font-semibold text-lg">
-        {icon}
-        <span>{title}</span>
-      </div>
-      {actions}
-    </div>
-    <div>{children}</div>
-  </div>
-);
 
 export default function AdminPanel() {
   const {
@@ -205,29 +193,32 @@ export default function AdminPanel() {
           <p className="text-sm text-gray-600 mb-4">Ingresa tus datos para asociarlos a tu billetera la primera vez.</p>
           <form onSubmit={handleUserSubmit(onRegisterUser)} className="grid gap-3">
             <div>
+              <label htmlFor="name" className="block text-sm font-medium mb-1">Nombre</label>
               <input
+                id="name"
                 className="border rounded-xl p-2 w-full"
                 placeholder="Nombre"
                 {...userForm("name", { required: "Nombre requerido" })}
-                aria-label="Nombre"
               />
               {userErrors.name && <span className="text-xs text-red-600">{userErrors.name.message}</span>}
             </div>
             <div>
+              <label htmlFor="surname" className="block text-sm font-medium mb-1">Apellido</label>
               <input
+                id="surname"
                 className="border rounded-xl p-2 w-full"
                 placeholder="Apellido"
                 {...userForm("surname", { required: "Apellido requerido" })}
-                aria-label="Apellido"
               />
               {userErrors.surname && <span className="text-xs text-red-600">{userErrors.surname.message}</span>}
             </div>
             <div>
+              <label htmlFor="dni" className="block text-sm font-medium mb-1">DNI</label>
               <input
+                id="dni"
                 className="border rounded-xl p-2 w-full"
                 placeholder="DNI"
                 {...userForm("dni", { required: "DNI requerido" })}
-                aria-label="DNI"
               />
               {userErrors.dni && <span className="text-xs text-red-600">{userErrors.dni.message}</span>}
             </div>
@@ -246,7 +237,7 @@ export default function AdminPanel() {
         <Card
           title={<div className="flex items-center gap-2"><Settings className="w-5 h-5"/> Administración</div>}
           icon={<span />}
-          className="bg-indigo-50"
+          className="bg-indigo-50 dark:bg-indigo-900"
           actions={
             <button
               onClick={() => setAdminOpen((v) => !v)}
@@ -266,12 +257,13 @@ export default function AdminPanel() {
                 <UserCog className="w-4 h-4" /> Gestión de administradores
               </div>
               <div className="flex flex-col sm:flex-row gap-2">
+                <label htmlFor="adminAddr" className="sr-only">Dirección del administrador</label>
                 <input
+                  id="adminAddr"
                   className="border rounded-xl p-2 flex-1"
                   placeholder="0x… address"
                   value={adminAddr}
                   onChange={(e) => setAdminAddr(e.target.value)}
-                  aria-label="Dirección del administrador"
                 />
                 <button
                   disabled={isBusy("addAdmin")}
@@ -352,11 +344,12 @@ export default function AdminPanel() {
               </div>
               <form onSubmit={handleGroupSubmit(onCreateGroup)} className="grid md:grid-cols-3 gap-2 items-center">
                 <div>
+                  <label htmlFor="groupName" className="block text-sm font-medium mb-1">Nombre del grupo</label>
                   <input
+                    id="groupName"
                     className="border rounded-xl p-2 w-full"
                     placeholder="Nombre del grupo"
                     {...groupForm("name", { required: "Nombre requerido" })}
-                    aria-label="Nombre del grupo"
                   />
                   {groupErrors?.name && <span className="text-xs text-red-600">{groupErrors.name.message}</span>}
                 </div>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,6 +11,7 @@ import "react-toastify/dist/ReactToastify.css";
 import AdminPanel from "./AdminPanel";
 import GroupList from "./GroupList";
 import ProposalList from "./ProposalList";
+import ThemeSwitcher from "./components/ThemeSwitcher";
 
 // ------------------ CONFIG ------------------
 const AMOY = {
@@ -1769,7 +1770,7 @@ export default function App() {
       csvData, setCsvData, baseAddresses, setBaseAddresses, run, withGas, isBusy, fetchAll,
       parseRemoteCSV, clearRosterAssociation, rosterIndex, demoGroups, demoProposals, registerUser
     }}>
-      <div className="min-h-screen bg-gray-50 p-4 md:p-8">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 dark:text-gray-100 p-4 md:p-8">
         <div className="max-w-6xl mx-auto space-y-6">
           <header className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
@@ -1777,6 +1778,7 @@ export default function App() {
               <p className="text-sm text-gray-500">Votaciones por grupos • MetaMask • Registro con hash • Modo Demo</p>
             </div>
             <div className="flex flex-wrap items-center gap-3">
+              <ThemeSwitcher />
               <label className="inline-flex items-center gap-2 text-sm">
                 <input type="checkbox" className="h-4 w-4" checked={demo} onChange={(e) => setDemo(e.target.checked)} aria-label="Activar modo demo" />
                 Modo demo

--- a/src/GroupList.jsx
+++ b/src/GroupList.jsx
@@ -2,33 +2,60 @@ import React from "react";
 import { useGroupDAO } from "./GroupDAOContext";
 import { Users, ChevronDown, ChevronRight, Loader2, X } from "lucide-react";
 import { toast } from "react-toastify";
+import Card from "./components/Card";
+import Skeleton from "./components/Skeleton";
 
-const Card = ({ title, icon, children, actions, className = "" }) => (
-  <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white"}`}>
-    <div className="flex items-center justify-between mb-3">
-      <div className="flex items-center gap-2 font-semibold text-lg">
-        {icon}
-        <span>{title}</span>
-      </div>
-      {actions}
-    </div>
-    <div>{children}</div>
-  </div>
-);
-
-const MembersModal = ({ groupId, onClose }) => {
+const MembersModal = ({ groupId, onClose, triggerRef }) => {
   const { demo, groups, demoGroups, groupMembersCache, rosterIndex } = useGroupDAO();
-  const g = (demo ? demoGroups : groups).find(x => x.id === groupId) || { name: `Grupo ${groupId}` };
+  const modalRef = React.useRef(null);
+  const closeRef = React.useRef(null);
+
+  const handleClose = React.useCallback(() => {
+    onClose();
+    triggerRef?.current?.focus();
+  }, [onClose, triggerRef]);
+
+  React.useEffect(() => {
+    const focusable = () => {
+      if (!modalRef.current) return [];
+      return modalRef.current.querySelectorAll(
+        'a[href], button, textarea, input, select, [tabindex]:not([tabindex="-1"])'
+      );
+    };
+    const trap = (e) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        handleClose();
+      } else if (e.key === "Tab") {
+        const nodes = focusable();
+        if (!nodes.length) return;
+        const first = nodes[0];
+        const last = nodes[nodes.length - 1];
+        if (e.shiftKey && document.activeElement === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && document.activeElement === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      }
+    };
+    document.addEventListener("keydown", trap);
+    closeRef.current?.focus();
+    return () => document.removeEventListener("keydown", trap);
+  }, [handleClose]);
+
+  const g = (demo ? demoGroups : groups).find((x) => x.id === groupId) || { name: `Grupo ${groupId}` };
   const addresses = demo
-    ? Array.from({ length: demoGroups.find(x => x.id === groupId)?.memberCount || 0 }).map((_, i) => `0xDEMO${i.toString().padStart(2, '0')}`)
-    : (groupMembersCache[groupId] || []);
+    ? Array.from({ length: demoGroups.find((x) => x.id === groupId)?.memberCount || 0 }).map((_, i) => `0xDEMO${i.toString().padStart(2, '0')}`)
+    : groupMembersCache[groupId] || [];
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50" role="dialog" aria-modal="true">
-      <div className="bg-white rounded-xl p-4 w-full max-w-lg max-h-[80vh] flex flex-col">
+      <div ref={modalRef} className="bg-white dark:bg-gray-800 rounded-xl p-4 w-full max-w-lg max-h-[80vh] flex flex-col">
         <div className="flex items-center justify-between mb-2">
           <h2 className="text-lg font-semibold">Integrantes de {g.name}</h2>
-          <button onClick={onClose} aria-label="Cerrar" className="text-gray-500 hover:text-gray-700">
+          <button ref={closeRef} onClick={handleClose} aria-label="Cerrar" className="text-gray-500 hover:text-gray-700">
             <X className="w-5 h-5" />
           </button>
         </div>
@@ -74,11 +101,14 @@ export default function GroupList() {
     openMembersGroup, setOpenMembersGroup, loadingGroups, demoGroups
   } = useGroupDAO();
 
-  const toggleMembers = async (groupId) => {
+  const modalTriggerRef = React.useRef(null);
+
+  const toggleMembers = async (groupId, e) => {
     if (openMembersGroup === groupId) {
       setOpenMembersGroup(null);
       return;
     }
+    modalTriggerRef.current = e?.currentTarget || null;
     setOpenMembersGroup(groupId);
     if (demo || groupMembersCache[groupId]) return;
     try {
@@ -99,26 +129,35 @@ export default function GroupList() {
         actions={loadingGroups && <div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="w-4 h-4 animate-spin" /> Actualizando grupos…</div>}
       >
         <div className="flex flex-wrap gap-2">
-          {(demo ? demoGroups.map(g => g.id) : myGroupIds).map(id => {
-            const g = (demo ? demoGroups : groups).find(x => x.id === id) || { name: `Grupo ${id}`, memberCount: 0 };
-            const open = openMembersGroup === id;
-            return (
-              <button
-                key={id}
-                onClick={() => toggleMembers(id)}
-                className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
-                aria-label={`Ver miembros del grupo ${g.name}`}
-              >
-                {open ? <ChevronDown className="w-3 h-3"/> : <ChevronRight className="w-3 h-3"/>}
-                {id} – {g.name}
-              </button>
-            );
-          })}
-          {(!demo && !myGroupIds.length) && <div className="text-sm text-gray-500">No integrás ningún grupo todavía.</div>}
+          {loadingGroups ? (
+            <>
+              <Skeleton className="h-6 w-32" />
+              <Skeleton className="h-6 w-24" />
+            </>
+          ) : (
+            <>
+              {(demo ? demoGroups.map(g => g.id) : myGroupIds).map(id => {
+                const g = (demo ? demoGroups : groups).find(x => x.id === id) || { name: `Grupo ${id}`, memberCount: 0 };
+                const open = openMembersGroup === id;
+                return (
+                  <button
+                    key={id}
+                    onClick={(e) => toggleMembers(id, e)}
+                    className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
+                    aria-label={`Ver miembros del grupo ${g.name}`}
+                  >
+                    {open ? <ChevronDown className="w-3 h-3"/> : <ChevronRight className="w-3 h-3"/>}
+                    {id} – {g.name}
+                  </button>
+                );
+              })}
+              {(!demo && !myGroupIds.length) && <div className="text-sm text-gray-500">No integrás ningún grupo todavía.</div>}
+            </>
+          )}
         </div>
       </Card>
       {openMembersGroup && (
-        <MembersModal groupId={openMembersGroup} onClose={() => setOpenMembersGroup(null)} />
+        <MembersModal groupId={openMembersGroup} onClose={() => setOpenMembersGroup(null)} triggerRef={modalTriggerRef} />
       )}
     </>
   );

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -4,23 +4,11 @@ import { Shield, ThumbsUp, ThumbsDown, CircleSlash, Loader2 } from "lucide-react
 import { toast } from "react-toastify";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
+import Card from "./components/Card";
+import Skeleton from "./components/Skeleton";
 
 // Función nowSec definida localmente
 const nowSec = () => Math.floor(Date.now() / 1000);
-
-// Componente Card
-const Card = ({ title, icon, children, actions, className = "" }) => (
-  <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white"}`}>
-    <div className="flex items-center justify-between mb-3">
-      <div className="flex items-center gap-2 font-semibold text-lg">
-        {icon}
-        <span>{title}</span>
-      </div>
-      {actions}
-    </div>
-    <div>{children}</div>
-  </div>
-);
 
 export default function ProposalList() {
   const {
@@ -183,7 +171,13 @@ export default function ProposalList() {
               aria-label="Filtrar votaciones en curso"
             />
           </div>
-          {(demo ? demoProposals : activeProposals).map(p => (
+          {loadingProposals ? (
+            <div className="space-y-2 mt-2">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-full" />
+            </div>
+          ) : (
+          (demo ? demoProposals : activeProposals).map(p => (
             <div key={p.id} className={`relative border rounded-xl p-3 ${nowSec() > p.endTime ? "bg-gray-50 border-gray-200" : "bg-white"}`}>
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
@@ -278,7 +272,8 @@ export default function ProposalList() {
                 </div>
               )}
             </div>
-          ))}
+          ))
+          )}
         </div>
         <div>
           <div className="flex justify-between">
@@ -292,7 +287,13 @@ export default function ProposalList() {
               aria-label="Filtrar votaciones finalizadas"
             />
           </div>
-          {(demo ? demoProposals : closedProposals).map(p => (
+          {loadingProposals ? (
+            <div className="space-y-2 mt-2">
+              <Skeleton className="h-6 w-full" />
+              <Skeleton className="h-6 w-full" />
+            </div>
+          ) : (
+          (demo ? demoProposals : closedProposals).map(p => (
             <div key={p.id} className="relative border rounded-xl p-3 bg-gray-50 border-gray-200">
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
@@ -330,7 +331,8 @@ export default function ProposalList() {
                 </div>
               </div>
             </div>
-          ))}
+          ))
+          )}
         </div>
       </div>
     </Card>

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -4,6 +4,7 @@ import { ListFilter, Loader2, Check, X } from "lucide-react";
 import { ethers } from "ethers";
 import { toast } from "react-toastify"; // Importar toast
 import Papa from "papaparse";
+import Skeleton from "./components/Skeleton";
 
 export default function RosterTable() {
   const {
@@ -149,20 +150,23 @@ export default function RosterTable() {
       <div className="grid md:grid-cols-4 gap-2 items-center mb-3">
         <div className="flex items-center gap-2">
           <ListFilter className="w-4 h-4" />
+          <label htmlFor="rosterFilter" className="text-sm font-medium">Filtro</label>
           <input
+            id="rosterFilter"
             className="border rounded-xl p-2 w-full"
             placeholder="Filtrar por nombre, apellido, DNI o address…"
             value={rosterFilter}
             onChange={(e) => setRosterFilter(e.target.value)}
-            aria-label="Filtrar roster"
           />
         </div>
-        <select
-          className="border rounded-xl p-2"
-          value={targetGroupId}
-          onChange={(e) => setTargetGroupId(e.target.value)}
-          aria-label="Seleccionar grupo para asignar usuarios"
-        >
+        <div>
+          <label htmlFor="targetGroup" className="block text-sm font-medium mb-1">Grupo</label>
+          <select
+            id="targetGroup"
+            className="border rounded-xl p-2 w-full"
+            value={targetGroupId}
+            onChange={(e) => setTargetGroupId(e.target.value)}
+          >
           <option value="">Elegí grupo…</option>
           {(demo ? demoGroups : groups).map((g) => (
             <option key={g.id} value={g.id}>
@@ -170,6 +174,7 @@ export default function RosterTable() {
             </option>
           ))}
         </select>
+        </div>
         <button
           disabled={isBusy("bulkAdd")}
           onClick={async () => {
@@ -193,7 +198,7 @@ export default function RosterTable() {
           Descargar CSV
         </button>
       </div>
-      <div className="max-h-60 overflow-auto border rounded-xl">
+      <div className="max-h-60 overflow-auto overflow-x-auto border rounded-xl">
         <table className="w-full text-sm">
           <thead className="bg-gray-100 sticky top-0">
             <tr>
@@ -206,39 +211,40 @@ export default function RosterTable() {
             </tr>
           </thead>
           <tbody>
-            {filteredRoster.map((r, idx) => {
-              const dni = r.dni || r.DNI || "";
-              const expected = chainHashes[r.address?.toLowerCase()] || "";
-              const hash = dni ? ethers.keccak256(ethers.toUtf8Bytes(dni)) : "";
-              const ok = expected && hash.toLowerCase() === expected.toLowerCase();
-              return (
-                <tr key={idx} className="border-t">
-                  <td className="p-2">
-                    <input
-                      type="checkbox"
-                      checked={!!rosterSelection[r.address]}
-                      onChange={(e) =>
-                        setRosterSelection((s) => ({ ...s, [r.address]: e.target.checked }))
-                      }
-                      aria-label={`Seleccionar ${r.name || r.address}`}
-                    />
-                  </td>
-                  <td className="p-2">{r.name || r.nombre || ""}</td>
-                  <td className="p-2">{r.surname || r.apellido || ""}</td>
-                  <td className="p-2">{dni}</td>
-                  <td className="p-2 font-mono">{r.address}</td>
-                  <td className="p-2 text-center">
-                    {ok ? <Check className="w-4 h-4 text-green-600" /> : <X className="w-4 h-4 text-red-600" />}
-                  </td>
-                </tr>
-              );
-            })}
-            {!filteredRoster.length && (
+            {!filteredRoster.length ? (
               <tr>
-                <td colSpan={6} className="p-3 text-center text-gray-500">
-                  Sin datos. Cargá un CSV/URL o asegurate de tener grupos con integrantes.
+                <td colSpan={6} className="p-4">
+                  <div className="flex justify-center"><Skeleton className="h-4 w-48" /></div>
                 </td>
               </tr>
+            ) : (
+              filteredRoster.map((r, idx) => {
+                const dni = r.dni || r.DNI || "";
+                const expected = chainHashes[r.address?.toLowerCase()] || "";
+                const hash = dni ? ethers.keccak256(ethers.toUtf8Bytes(dni)) : "";
+                const ok = expected && hash.toLowerCase() === expected.toLowerCase();
+                return (
+                  <tr key={idx} className="border-t">
+                    <td className="p-2">
+                      <input
+                        type="checkbox"
+                        checked={!!rosterSelection[r.address]}
+                        onChange={(e) =>
+                          setRosterSelection((s) => ({ ...s, [r.address]: e.target.checked }))
+                        }
+                        aria-label={`Seleccionar ${r.name || r.address}`}
+                      />
+                    </td>
+                    <td className="p-2">{r.name || r.nombre || ""}</td>
+                    <td className="p-2">{r.surname || r.apellido || ""}</td>
+                    <td className="p-2">{dni}</td>
+                    <td className="p-2 font-mono">{r.address}</td>
+                    <td className="p-2 text-center">
+                      {ok ? <Check className="w-4 h-4 text-green-600" /> : <X className="w-4 h-4 text-red-600" />}
+                    </td>
+                  </tr>
+                );
+              })
             )}
           </tbody>
         </table>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+export default function Card({ title, icon, children, actions, className = "" }) {
+  return (
+    <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white dark:bg-gray-800"}`}>
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2 font-semibold text-lg">
+          {icon}
+          <span>{title}</span>
+        </div>
+        {actions}
+      </div>
+      <div>{children}</div>
+    </div>
+  );
+}

--- a/src/components/Skeleton.jsx
+++ b/src/components/Skeleton.jsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+export default function Skeleton({ className = "" }) {
+  return <div className={`animate-pulse bg-gray-200 dark:bg-gray-700 rounded ${className}`}></div>;
+}

--- a/src/components/ThemeSwitcher.jsx
+++ b/src/components/ThemeSwitcher.jsx
@@ -1,0 +1,28 @@
+import React, { useEffect, useState } from "react";
+
+export default function ThemeSwitcher() {
+  const [dark, setDark] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") === "dark";
+    setDark(stored);
+    document.documentElement.classList.toggle("dark", stored);
+  }, []);
+
+  const toggle = () => {
+    const next = !dark;
+    setDark(next);
+    document.documentElement.classList.toggle("dark", next);
+    localStorage.setItem("theme", next ? "dark" : "light");
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className="px-3 py-2 rounded-xl border text-sm"
+      aria-label="Cambiar tema"
+    >
+      {dark ? "Modo claro" : "Modo oscuro"}
+    </button>
+  );
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
+  darkMode: "class",
   content: ["./index.html", "./src/**/*.{js,jsx,ts,tsx}"],
   theme: { extend: {} },
   plugins: [],


### PR DESCRIPTION
## Summary
- centralize Card component and add theme switcher with dark mode
- improve form labels and modal accessibility
- add skeleton loaders and responsive tweaks

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8cd6a9c6c833392eab65cb16a91cb