### PR TITLE
Fix dark mode styling for subsections

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -188,7 +188,7 @@ export default function AdminPanel() {
   return (
     <>
       {contract && account && registered !== true && (
-        <div className="mb-4 p-4 border rounded-xl bg-white shadow-sm">
+        <div className="mb-4 p-4 border rounded-xl bg-white dark:bg-gray-800 dark:border-gray-700 shadow-sm">
           <h3 className="text-lg font-semibold mb-2">Registro de Usuario</h3>
           <p className="text-sm text-gray-600 mb-4">Ingresa tus datos para asociarlos a tu billetera la primera vez.</p>
           <form onSubmit={handleUserSubmit(onRegisterUser)} className="grid gap-3">
@@ -252,7 +252,7 @@ export default function AdminPanel() {
           {adminOpen && (
             <div className="grid grid-cols-1 gap-6 w-full">
             {/* Gestión de administradores */}
-            <div className="border rounded-xl p-3 bg-white">
+            <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <UserCog className="w-4 h-4" /> Gestión de administradores
               </div>
@@ -268,7 +268,7 @@ export default function AdminPanel() {
                 <button
                   disabled={isBusy("addAdmin")}
                   onClick={onAddAdmin}
-                  className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100"
+                  className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:border-gray-600"
                   aria-label="Agregar administrador"
                 >
                   {isBusy("addAdmin") && <Loader2 className="w-4 h-4 animate-spin" />} Agregar
@@ -276,7 +276,7 @@ export default function AdminPanel() {
                 <button
                   disabled={isBusy("rmAdmin")}
                   onClick={onRemoveAdmin}
-                  className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100"
+                  className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:border-gray-600"
                   aria-label="Revocar administrador"
                 >
                   {isBusy("rmAdmin") && <Loader2 className="w-4 h-4 animate-spin" />} Revocar
@@ -297,7 +297,7 @@ export default function AdminPanel() {
 
             {/* Pausabilidad */}
             {isOwner && (
-              <div className="border rounded-xl p-3 bg-white">
+              <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <Shield className="w-4 h-4" /> Control del contrato
                   <span
@@ -338,7 +338,7 @@ export default function AdminPanel() {
             )}
 
             {/* Creación de grupo */}
-            <div className="border rounded-xl p-3 bg-white">
+            <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <Users className="w-4 h-4" /> Creación de grupo
               </div>
@@ -366,7 +366,7 @@ export default function AdminPanel() {
             </div>
 
             {/* Listado de grupos */}
-            <div className="border rounded-xl p-3 bg-white">
+            <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <Users className="w-4 h-4" /> Grupos existentes
               </div>
@@ -378,14 +378,14 @@ export default function AdminPanel() {
                     <div key={id}>
                       <button
                         onClick={() => toggleMembers(id)}
-                        className={`mr-2 mb-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
+                        className={`mr-2 mb-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs ring-1 ring-gray-200 dark:ring-gray-600 ${open ? "bg-gray-100 dark:bg-gray-700" : "bg-white dark:bg-gray-800"}`}
                         aria-label={`Toggle miembros del grupo ${g.name}`}
                       >
                         {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
                         {id} – {g.name}
                       </button>
                       {open && (
-                        <div className="mt-1 mb-3 ml-2 p-2 border rounded-xl bg-gray-50 max-h-40 overflow-auto text-xs">
+                        <div className="mt-1 mb-3 ml-2 p-2 border rounded-xl bg-gray-50 dark:bg-gray-700 dark:border-gray-600 max-h-40 overflow-auto text-xs">
                           <div className="mb-1 text-gray-600">
                             Integrantes ({demo ? (demoGroups.find((x) => x.id === id)?.memberCount || 0) : (groupMembersCache[id]?.length ?? g.memberCount)}):
                           </div>
@@ -412,7 +412,7 @@ export default function AdminPanel() {
             </div>
 
             {/* Creación de propuesta */}
-            <div className="border rounded-xl p-3 bg-white">
+            <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <Shield className="w-4 h-4" /> Crear propuesta
               </div>
@@ -484,7 +484,7 @@ export default function AdminPanel() {
             </div>
 
             {/* Gestión de roster */}
-            <div className="border rounded-xl p-3 bg-white">
+            <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
                 <Users className="w-4 h-4" /> Gestión de roster
               </div>
@@ -502,7 +502,7 @@ export default function AdminPanel() {
                   </div>
                   <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
                     <button
-                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100"
+                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:border-gray-600"
                       disabled={isBusy("loadRosterURL")}
                       onClick={() =>
                         run("loadRosterURL", async () => {
@@ -514,7 +514,7 @@ export default function AdminPanel() {
                       {isBusy("loadRosterURL") && <Loader2 className="w-4 h-4 animate-spin" />} Cargar remoto
                     </button>
                     <button
-                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100"
+                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-gray-50 hover:bg-gray-100 dark:bg-gray-700 dark:hover:bg-gray-600 dark:border-gray-600"
                       disabled={isBusy("saveRosterURL")}
                       onClick={() =>
                         run("saveRosterURL", async () => {
@@ -533,7 +533,7 @@ export default function AdminPanel() {
                       {isBusy("saveRosterURL") && <Loader2 className="w-4 h-4 animate-spin" />} Publicar URL
                     </button>
                     <button
-                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-white hover:bg-gray-50"
+                      className="rounded-xl border px-3 py-2 text-sm flex items-center gap-2 bg-white hover:bg-gray-50 dark:bg-gray-800 dark:hover:bg-gray-700 dark:border-gray-700"
                       onClick={clearRosterAssociation}
                       aria-label="Limpiar padrón"
                     >

--- a/src/GroupList.jsx
+++ b/src/GroupList.jsx
@@ -66,7 +66,7 @@ const MembersModal = ({ groupId, onClose, triggerRef }) => {
             </div>
           ) : (
             <table className="w-full text-sm">
-              <thead className="bg-gray-100 sticky top-0">
+              <thead className="bg-gray-100 dark:bg-gray-700 sticky top-0">
                 <tr>
                   <th className="p-2 text-left">Nombre</th>
                   <th className="p-2 text-left">Apellido</th>
@@ -78,7 +78,7 @@ const MembersModal = ({ groupId, onClose, triggerRef }) => {
                 {addresses.map((addr, i) => {
                   const meta = rosterIndex.get((addr || "").toLowerCase()) || {};
                   return (
-                    <tr key={i} className="border-t">
+                    <tr key={i} className="border-t dark:border-gray-700">
                       <td className="p-2">{meta.name || ""}</td>
                       <td className="p-2">{meta.surname || ""}</td>
                       <td className="p-2">{meta.dni || ""}</td>
@@ -143,7 +143,7 @@ export default function GroupList() {
                   <button
                     key={id}
                     onClick={(e) => toggleMembers(id, e)}
-                    className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 ${open ? "bg-gray-100" : "bg-white"}`}
+                    className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 dark:ring-gray-600 ${open ? "bg-gray-100 dark:bg-gray-700" : "bg-white dark:bg-gray-800"}`}
                     aria-label={`Ver miembros del grupo ${g.name}`}
                   >
                     {open ? <ChevronDown className="w-3 h-3"/> : <ChevronRight className="w-3 h-3"/>}

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -178,7 +178,7 @@ export default function ProposalList() {
             </div>
           ) : (
           (demo ? demoProposals : activeProposals).map(p => (
-            <div key={p.id} className={`relative border rounded-xl p-3 ${nowSec() > p.endTime ? "bg-gray-50 border-gray-200" : "bg-white"}`}>
+            <div key={p.id} className={`relative border rounded-xl p-3 ${nowSec() > p.endTime ? "bg-gray-50 border-gray-200 dark:bg-gray-700 dark:border-gray-600" : "bg-white dark:bg-gray-800 dark:border-gray-700"}`}> 
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
                   const g = (demo ? demoGroups : groups).find(x => x.id === gid) || { id: gid, name: `Grupo ${gid}` };
@@ -186,7 +186,7 @@ export default function ProposalList() {
                     <span
                       key={gid}
                       title="Grupos que intervienen en esta votación"
-                      className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
+                      className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300"
                     >
                       {g.id} – {g.name}
                     </span>
@@ -204,7 +204,7 @@ export default function ProposalList() {
                 <button
                   className={`rounded-xl px-3 py-2 flex items-center gap-2 text-sm font-medium transition ${
                     nowSec() > p.endTime || p.myVote !== 0 || isBusy(`vote:${p.id}`)
-                      ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+                      ? "bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-400"
                       : "bg-green-600 text-white hover:bg-green-700"
                 }`}
                   onClick={() => actionVote(p, 1)}
@@ -216,7 +216,7 @@ export default function ProposalList() {
                 <button
                   className={`rounded-xl px-3 py-2 flex items-center gap-2 text-sm font-medium transition ${
                     nowSec() > p.endTime || p.myVote !== 0 || isBusy(`vote:${p.id}`)
-                      ? "bg-gray-200 text-gray-500 cursor-not-allowed"
+                      ? "bg-gray-200 text-gray-500 cursor-not-allowed dark:bg-gray-700 dark:text-gray-400"
                       : "bg-red-600 text-white hover:bg-red-700"
                   }`}
                   onClick={() => actionVote(p, 2)}
@@ -294,7 +294,7 @@ export default function ProposalList() {
             </div>
           ) : (
           (demo ? demoProposals : closedProposals).map(p => (
-            <div key={p.id} className="relative border rounded-xl p-3 bg-gray-50 border-gray-200">
+            <div key={p.id} className="relative border rounded-xl p-3 bg-gray-50 border-gray-200 dark:bg-gray-700 dark:border-gray-600">
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
                   const g = (demo ? demoGroups : groups).find(x => x.id === gid) || { id: gid, name: `Grupo ${gid}` };
@@ -302,7 +302,7 @@ export default function ProposalList() {
                     <span
                       key={gid}
                       title="Grupos que intervienen en esta votación"
-                      className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700"
+                      className="inline-flex items-center rounded-md border border-gray-300 bg-gray-100 px-2 py-0.5 text-xs text-gray-700 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-300"
                     >
                       {g.id} – {g.name}
                     </span>

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Card({ title, icon, children, actions, className = "" }) {
   return (
-    <div className={`rounded-2xl shadow-sm border p-4 ${className || "bg-white dark:bg-gray-800"}`}>
+    <div className={`rounded-2xl shadow-sm border p-4 bg-white dark:bg-gray-800 ${className}`}>
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2 font-semibold text-lg">
           {icon}


### PR DESCRIPTION
## Summary
- ensure group lists and member tables respect dark theme
- add dark-mode styling for proposal cards and admin controls
- include default dark styles in Card component to preserve theme

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8f3d053688333a3101145183d84f2