### PR TITLE
fix: style inputs in dark mode

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,11 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  input,
+  textarea,
+  select {
+    @apply bg-white text-gray-900 placeholder-gray-500 border-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:placeholder-gray-400 dark:border-gray-600;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure form fields adapt to dark mode

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a8fa82a5cc8333bf4c41a8abd94379