### PR TITLE
Improve group creation and roster management UI

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -2,7 +2,7 @@ import React, { useEffect } from "react";
 import { useGroupDAO } from "./GroupDAOContext";
 import { useForm } from "react-hook-form";
 import { ethers } from "ethers";
-import { UserCog, Users, ListFilter, Loader2, Link as LinkIcon, Settings, ChevronRight, ChevronDown, Shield, Pause, Play } from "lucide-react";
+import { UserCog, Users, ListFilter, Loader2, Link as LinkIcon, Settings, ChevronRight, ChevronDown, FileText, Shield, Pause, Play } from "lucide-react";
 import { toast } from "react-toastify";
 import RosterTable from "./RosterTable";
 import Card from "./components/Card";
@@ -299,7 +299,7 @@ export default function AdminPanel() {
             {isOwner && (
               <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
               <div className="flex flex-wrap items-center gap-2 mb-2 text-sm font-medium">
-                <Shield className="w-4 h-4" /> Control del contrato
+                <FileText className="w-4 h-4" /> Control del contrato
                   <span
                     className={`ml-auto px-2 py-0.5 rounded-full text-xs ${paused ? "bg-red-100 text-red-600" : "bg-green-100 text-green-600"}`}
                   >
@@ -343,11 +343,11 @@ export default function AdminPanel() {
                 <Users className="w-4 h-4" /> Creación de grupo
               </div>
               <form onSubmit={handleGroupSubmit(onCreateGroup)} className="flex flex-wrap gap-2 items-end">
-                <div className="flex-1 min-w-[200px]">
+                <div className="w-1/2 min-w-[200px]">
                   <label htmlFor="groupName" className="block text-sm font-medium mb-1">Nombre del grupo</label>
                   <input
                     id="groupName"
-                    className="border rounded-xl p-2 w-full"
+                    className="border rounded-xl p-2 w-full h-10"
                     placeholder="Nombre del grupo"
                     {...groupForm("name", { required: "Nombre requerido" })}
                   />
@@ -356,7 +356,7 @@ export default function AdminPanel() {
                 <button
                   disabled={isBusy("createGroup")}
                   type="submit"
-                  className="w-fit rounded-xl bg-black text-white px-3 py-1 flex items-center justify-center gap-2 hover:opacity-90"
+                  className="w-fit rounded-xl bg-black text-white px-3 h-10 flex items-center justify-center gap-2 hover:opacity-90"
                   aria-label="Crear grupo"
                 >
                   {isBusy("createGroup") && <Loader2 className="w-4 h-4 animate-spin" />} Crear grupo
@@ -377,7 +377,7 @@ export default function AdminPanel() {
                     <div key={id}>
                       <button
                         onClick={() => toggleMembers(id)}
-                        className={`mr-2 mb-2 inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs ring-1 ring-gray-200 dark:ring-gray-600 ${open ? "bg-gray-100 dark:bg-gray-700" : "bg-white dark:bg-gray-800"}`}
+                        className={`mr-2 mb-2 inline-flex items-center gap-1 px-3 py-1.5 rounded-full text-sm ring-1 ring-gray-200 dark:ring-gray-600 ${open ? "bg-gray-100 dark:bg-gray-700" : "bg-white dark:bg-gray-800"}`}
                         aria-label={`Toggle miembros del grupo ${g.name}`}
                       >
                         {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -147,26 +147,23 @@ export default function RosterTable() {
   return (
     <div className="mt-4">
       <div className="text-sm font-semibold mb-2">Agregar personas a grupo</div>
-      <div className="grid md:grid-cols-4 gap-2 items-center mb-3">
-        <div className="flex items-center gap-2">
-          <ListFilter className="w-4 h-4" />
-          <label htmlFor="rosterFilter" className="text-sm font-medium">Filtro</label>
-          <input
-            id="rosterFilter"
-            className="border rounded-xl p-2 w-full"
-            placeholder="Filtrar por nombre, apellido, DNI o address…"
-            value={rosterFilter}
-            onChange={(e) => setRosterFilter(e.target.value)}
-          />
-        </div>
-        <div>
-          <label htmlFor="targetGroup" className="block text-sm font-medium mb-1">Grupo</label>
-          <select
-            id="targetGroup"
-            className="border rounded-xl p-2 w-full"
-            value={targetGroupId}
-            onChange={(e) => setTargetGroupId(e.target.value)}
-          >
+      <div className="flex flex-wrap items-center gap-2 mb-3">
+        <ListFilter className="w-4 h-4" />
+        <label htmlFor="rosterFilter" className="text-sm font-medium">Filtro</label>
+        <input
+          id="rosterFilter"
+          className="border rounded-xl p-2 h-10 min-w-[180px]"
+          placeholder="Filtrar por nombre, apellido, DNI o address…"
+          value={rosterFilter}
+          onChange={(e) => setRosterFilter(e.target.value)}
+        />
+        <select
+          id="targetGroup"
+          className="border rounded-xl p-2 h-10 min-w-[180px]"
+          value={targetGroupId}
+          onChange={(e) => setTargetGroupId(e.target.value)}
+          aria-label="Elegí grupo"
+        >
           <option value="">Elegí grupo…</option>
           {(demo ? demoGroups : groups).map((g) => (
             <option key={g.id} value={g.id}>
@@ -174,7 +171,6 @@ export default function RosterTable() {
             </option>
           ))}
         </select>
-        </div>
         <button
           disabled={isBusy("bulkAdd")}
           onClick={async () => {
@@ -185,14 +181,14 @@ export default function RosterTable() {
             if (!addrs.length) return toast.error("Seleccioná al menos una persona");
             await actionBulkAddToGroup(addrs, targetGroupId);
           }}
-          className="rounded-xl bg-black text-white px-4 py-2 flex items-center gap-2 hover:opacity-90"
+          className="rounded-xl bg-black text-white px-4 h-10 flex items-center gap-2 hover:opacity-90"
           aria-label="Agregar usuarios seleccionados al grupo"
         >
           {isBusy("bulkAdd") && <Loader2 className="w-4 h-4 animate-spin" />} Agregar seleccionados
         </button>
         <button
           onClick={downloadCSV}
-          className="rounded-xl bg-blue-600 text-white px-4 py-2 hover:opacity-90"
+          className="rounded-xl bg-blue-600 text-white px-4 h-10 hover:opacity-90"
           aria-label="Descargar roster como CSV"
         >
           Descargar CSV


### PR DESCRIPTION
## Summary
- Unify contract control icon with a document-style symbol
- Align group creation form sizing and existing group tags with "Mis grupos"
- Streamline roster management filter row and align all controls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68a9bfbc5d888333bdc749cf6fa675cc