### PR TITLE
Ocultar sección de registro hasta validar usuario

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -187,7 +187,7 @@ export default function AdminPanel() {
 
   return (
     <>
-      {contract && account && registered !== true && (
+      {contract && account && registered === false && (
         <div className="mb-4 p-4 border rounded-xl bg-white dark:bg-gray-800 dark:border-gray-700 shadow-sm">
           <h3 className="text-lg font-semibold mb-2">Registro de Usuario</h3>
           <p className="text-sm text-gray-600 mb-4">Ingresa tus datos para asociarlos a tu billetera la primera vez.</p>


### PR DESCRIPTION
## Resumen
- Oculta la sección de registro de usuario hasta confirmar que la cuenta no está registrada.

## Testing
- `npm test` *(falla: Missing script "test")*
- `npm run lint` *(falla: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ab1f5f826c8333b815e98ecae59637