### PR TITLE
Reorganiza secciones y ajusta notificaciones de error

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -74,7 +74,7 @@ export default function AdminPanel() {
   };
 
   const onCreateGroup = async (data) => {
-    if (demo) return toast.success("Demo: grupo creado");
+    if (demo) return;
     await run("createGroup", async () => {
       const tx = await withGas(
         contract.createGroup.estimateGas(data.name),
@@ -87,7 +87,7 @@ export default function AdminPanel() {
   };
 
   const onCreateProposal = async (data) => {
-    if (demo) return toast.success("Demo: propuesta creada");
+    if (demo) return;
     if (!contract) return toast.error("Conectá tu wallet");
     if (!isAdmin) return toast.error("Solo admins pueden crear propuestas");
     const { title, description, groupId, startDate, endDate } = data;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1351,7 +1351,6 @@ export default function App() {
     setBusy((s) => ({ ...s, [key]: true }));
     try {
       await fn();
-      toast.success(`Acción ${key} completada con éxito`);
     } catch (e) {
       let msg = e?.shortMessage || e?.message || "Error en la acción";
       const lower = msg.toLowerCase();
@@ -1462,7 +1461,7 @@ export default function App() {
     }
 
     if (addrsSet.size === 0 && !demo) {
-      toast.warn("No se encontraron usuarios registrados. Verifica el contrato o carga un CSV.");
+      toast.error("No se encontraron usuarios registrados. Verifica el contrato o carga un CSV.");
     }
 
     return Array.from(addrsSet.values());
@@ -1743,7 +1742,7 @@ export default function App() {
 
   // ------------------ Nueva Función: registerUser ------------------
   const registerUser = useCallback(async (name, surname, dni) => {
-    if (demo) return toast.success("Demo: usuario registrado");
+    if (demo) return;
     if (!contract || !account) return toast.error("Conectá tu wallet");
     const fullName = `${name} ${surname}`.trim();
     const dniHash = ethers.keccak256(ethers.toUtf8Bytes(dni));
@@ -1756,7 +1755,6 @@ export default function App() {
       await tx.wait();
       setRegistered(true); // Actualizar estado de registro
       await fetchAll(); // Refrescar datos
-      toast.success("Usuario registrado exitosamente");
     });
   }, [contract, account, demo, run, fetchAll]);
 
@@ -1808,12 +1806,12 @@ export default function App() {
           )}
 
           <AdminPanel />
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div className="space-y-6">
             <GroupList />
             <ProposalList />
           </div>
         </div>
-        <ToastContainer position="top-right" autoClose={3000} />
+        <ToastContainer position="top-right" autoClose={10000} />
       </div>
     </GroupDAOContext.Provider>
   );

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -113,7 +113,7 @@ export default function ProposalList() {
 
   const actionVote = async (p, choice) => {
     const pid = p.id;
-    if (demo) return toast.success(`Demo: votaste ${choice === 1 ? "👍" : "👎"}`);
+    if (demo) return;
     await run(`vote:${pid}`, async () => {
       const tx = await withGas(
         contract.vote.estimateGas(pid, choice),
@@ -128,7 +128,7 @@ export default function ProposalList() {
 
   const actionRetractVote = async (p) => {
     const pid = p.id;
-    if (demo) return toast.success("Demo: retractaste tu voto");
+    if (demo) return;
     await run(`retract:${pid}`, async () => {
       let tx;
       try {
@@ -158,9 +158,9 @@ export default function ProposalList() {
       icon={<Shield className="w-5 h-5" />}
       actions={<div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="w-4 h-4 animate-spin" hidden={!loadingProposals} /> {loadingProposals && "Actualizando votaciones…"}</div>}
     >
-      <div className="space-y-3">
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div>
-          <div className="flex justify-between">
+          <div className="flex justify-between mb-2">
             <h2 className="text-sm font-semibold">Votaciones en curso</h2>
             <input
               type="text"
@@ -276,7 +276,7 @@ export default function ProposalList() {
           )}
         </div>
         <div>
-          <div className="flex justify-between">
+          <div className="flex justify-between mb-2">
             <h2 className="text-sm font-semibold">Votaciones finalizadas</h2>
             <input
               type="text"

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -59,7 +59,7 @@ export default function RosterTable() {
   }, [contract, roster]);
 
   const actionBulkAddToGroup = async (addrs, gid) => {
-    if (demo) return toast.success("Demo: asignación simulada");
+    if (demo) return;
 
     // Cargar miembros existentes para evitar duplicados
     let existing = groupMembersCache[gid];
@@ -78,11 +78,11 @@ export default function RosterTable() {
     const uniqueAddrs = addrs.filter((a) => !existingSet.has(a.toLowerCase()));
     const skipped = addrs.length - uniqueAddrs.length;
     if (!uniqueAddrs.length) {
-      toast.info("Todos los usuarios seleccionados ya están en el grupo");
+      toast.error("Todos los usuarios seleccionados ya están en el grupo");
       return;
     }
     if (skipped)
-      toast.info(
+      toast.error(
         `${skipped} persona${skipped > 1 ? "s" : ""} ya integraba el grupo y fue omitida`
       );
 


### PR DESCRIPTION
## Resumen
- Reordena la interfaz ubicando los grupos antes de las votaciones y usando todo el ancho disponible.
- Muestra votaciones en curso y finalizadas en columnas paralelas con filtros separados del contenido.
- Elimina los avisos de éxito y extiende la duración de los mensajes de error.

## Pruebas
- `npm test` *(falla: Missing script "test"))*
- `npm run lint` *(falla: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab827c72c8833390c84869466814ba