### PR TITLE
Add react-router-dom dependency and fix lint

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
+    "react-router-dom": "^6.23.0",
     "react-toastify": "^11.0.5"
   },
   "devDependencies": {

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useMemo } from "react";
 import { useGroupDAO } from "./GroupDAOContext";
 import { Shield, ThumbsUp, ThumbsDown, CircleSlash, Loader2 } from "lucide-react";
-import { toast } from "react-toastify";
 import { format } from "date-fns";
 import { es } from "date-fns/locale";
 import Card from "./components/Card";


### PR DESCRIPTION
## Summary
- add `react-router-dom` dependency so local build can resolve BrowserRouter
- remove unused `toast` import in `ProposalList`

## Testing
- `npm run lint`
- `npm run build` *(fails: could not resolve `react-router-dom`; install dependency to resolve)*

------
https://chatgpt.com/codex/tasks/task_e_68ac88058fcc8333b1ed9d42f609b98a