### PR TITLE
Use npm install in GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Build (Vite)
         run: |


### PR DESCRIPTION
## Summary
- fix GitHub Pages workflow to install dependencies using `npm install`

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Rollup failed to resolve import "react-router-dom")*


------
https://chatgpt.com/codex/tasks/task_e_68ac8c54110083338f224df65a950ebf