### PR TITLE
Improve voting layout and dark mode contrast

### DIFF
--- a/src/AdminPanel.jsx
+++ b/src/AdminPanel.jsx
@@ -225,7 +225,7 @@ export default function AdminPanel() {
             <button
               disabled={isBusy("registerUser")}
               type="submit"
-              className="rounded-xl bg-black text-white px-4 py-2 flex items-center gap-2 hover:opacity-90"
+              className="rounded-xl bg-black text-white dark:bg-white dark:text-black px-4 py-2 flex items-center gap-2 hover:opacity-90"
               aria-label="Registrar usuario"
             >
               {isBusy("registerUser") && <Loader2 className="w-4 h-4 animate-spin" />} Registrar
@@ -362,7 +362,7 @@ export default function AdminPanel() {
                 <button
                   disabled={isBusy("createGroup")}
                   type="submit"
-                  className="w-fit rounded-xl bg-black text-white px-3 h-10 flex items-center justify-center gap-2 hover:opacity-90"
+                  className="w-fit rounded-xl bg-black text-white dark:bg-white dark:text-black px-3 h-10 flex items-center justify-center gap-2 hover:opacity-90"
                   aria-label="Crear grupo"
                 >
                   {isBusy("createGroup") && <Loader2 className="w-4 h-4 animate-spin" />} Crear grupo
@@ -486,7 +486,7 @@ export default function AdminPanel() {
                 <button
                   disabled={isBusy("createProposal")}
                   type="submit"
-                  className="rounded-xl bg-black text-white px-4 py-2 flex items-center gap-2 hover:opacity-90 w-fit justify-self-start"
+                  className="rounded-xl bg-black text-white dark:bg-white dark:text-black px-4 py-2 flex items-center gap-2 hover:opacity-90 w-fit justify-self-start"
                   aria-label="Crear propuesta"
                 >
                   {isBusy("createProposal") && <Loader2 className="w-4 h-4 animate-spin" />} Crear propuesta

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1785,7 +1785,7 @@ export default function App() {
                 <RefreshCcw className={`w-4 h-4 ${loadingAll ? "animate-spin" : ""}`} /> {loadingAll ? 'Actualizando…' : 'Actualizar'}
               </button>
               {!account ? (
-                <button onClick={connect} disabled={isBusy('connect')} className="px-3 py-2 rounded-xl bg-black text-white flex items-center gap-1 disabled:opacity-50" aria-label="Conectar wallet">
+                <button onClick={connect} disabled={isBusy('connect')} className="px-3 py-2 rounded-xl bg-black text-white dark:bg-white dark:text-black flex items-center gap-1 disabled:opacity-50" aria-label="Conectar wallet">
                   {isBusy('connect') && <Loader2 className="w-4 h-4 animate-spin"/>}
                   <LogIn className="w-4 h-4"/> Conectar
                 </button>

--- a/src/ProposalList.jsx
+++ b/src/ProposalList.jsx
@@ -158,7 +158,7 @@ export default function ProposalList() {
       actions={<div className="flex items-center gap-2 text-sm text-gray-500"><Loader2 className="w-4 h-4 animate-spin" hidden={!loadingProposals} /> {loadingProposals && "Actualizando votaciones…"}</div>}
     >
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-        <div>
+        <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
           <div className="flex justify-between mb-2">
             <h2 className="text-sm font-semibold">Votaciones en curso</h2>
             <input
@@ -176,8 +176,9 @@ export default function ProposalList() {
               <Skeleton className="h-6 w-full" />
             </div>
           ) : (
-          (demo ? demoProposals : activeProposals).map(p => (
-            <div key={p.id} className={`relative border-2 rounded-xl p-3 shadow-sm ${nowSec() > p.endTime ? "bg-gray-50 border-gray-300 dark:bg-gray-700 dark:border-gray-500" : "bg-white border-gray-300 dark:bg-gray-800 dark:border-gray-600"}`}>
+            <div className="mt-2 space-y-3">
+              {(demo ? demoProposals : activeProposals).map(p => (
+                <div key={p.id} className={`relative border-2 rounded-xl p-3 shadow-sm ${nowSec() > p.endTime ? "bg-gray-50 border-gray-300 dark:bg-gray-700 dark:border-gray-500" : "bg-white border-gray-300 dark:bg-gray-800 dark:border-gray-600"}`}>
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
                   const g = (demo ? demoGroups : groups).find(x => x.id === gid) || { id: gid, name: `Grupo ${gid}` };
@@ -271,10 +272,11 @@ export default function ProposalList() {
                 </div>
               )}
             </div>
-          ))
+              ))}
+            </div>
           )}
         </div>
-        <div>
+        <div className="border rounded-xl p-3 bg-white dark:bg-gray-800 dark:border-gray-700">
           <div className="flex justify-between mb-2">
             <h2 className="text-sm font-semibold">Votaciones finalizadas</h2>
             <input
@@ -292,8 +294,9 @@ export default function ProposalList() {
               <Skeleton className="h-6 w-full" />
             </div>
           ) : (
-          (demo ? demoProposals : closedProposals).map(p => (
-            <div key={p.id} className="relative border-2 rounded-xl p-3 shadow-sm bg-gray-50 border-gray-300 dark:bg-gray-700 dark:border-gray-500">
+            <div className="mt-2 space-y-3">
+              {(demo ? demoProposals : closedProposals).map(p => (
+                <div key={p.id} className="relative border-2 rounded-xl p-3 shadow-sm bg-gray-50 border-gray-300 dark:bg-gray-700 dark:border-gray-500">
               <div className="absolute top-2 right-2 flex flex-wrap gap-1 justify-end">
                 {(p.groupIds || [p.groupId]).map(gid => {
                   const g = (demo ? demoGroups : groups).find(x => x.id === gid) || { id: gid, name: `Grupo ${gid}` };
@@ -330,7 +333,8 @@ export default function ProposalList() {
                 </div>
               </div>
             </div>
-          ))
+              ))}
+            </div>
           )}
         </div>
       </div>

--- a/src/RosterTable.jsx
+++ b/src/RosterTable.jsx
@@ -180,7 +180,7 @@ export default function RosterTable() {
             if (!addrs.length) return toast.error("Seleccioná al menos una persona");
             await actionBulkAddToGroup(addrs, targetGroupId);
           }}
-          className="rounded-xl bg-black text-white px-4 h-10 flex items-center gap-2 hover:opacity-90"
+          className="rounded-xl bg-black text-white dark:bg-white dark:text-black px-4 h-10 flex items-center gap-2 hover:opacity-90"
           aria-label="Agregar usuarios seleccionados al grupo"
         >
           {isBusy("bulkAdd") && <Loader2 className="w-4 h-4 animate-spin" />} Agregar seleccionados

--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,8 +1,8 @@
 import React from "react";
 
-export default function Card({ title, icon, children, actions, className = "" }) {
+export default function Card({ title, icon, children, actions, className = "bg-white dark:bg-gray-800" }) {
   return (
-    <div className={`rounded-2xl shadow-sm border p-4 bg-white dark:bg-gray-800 ${className}`}>
+    <div className={`rounded-2xl shadow-sm border p-4 ${className}`}>
       <div className="flex items-center justify-between mb-3">
         <div className="flex items-center gap-2 font-semibold text-lg">
           {icon}


### PR DESCRIPTION
## Summary
- Add spacing between voting cards and wrap current/finished voting sections in bordered containers
- Allow Card background customization and restore admin panel background color
- Change black buttons to white in dark mode for better readability

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; `npm install` returns 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac9c1c179883339cab275f624f8fe4