### PR TITLE
fix: drop viem/ethers dependency

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,13 @@ import GroupList from "./GroupList";
 import ProposalList from "./ProposalList";
 import ThemeSwitcher from "./components/ThemeSwitcher";
 import { useAccount, useWalletClient } from "wagmi";
-import { walletClientToSigner } from "viem/ethers";
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+
+// Utility to bridge a viem wallet client to an ethers Signer
+async function walletClientToSigner(walletClient) {
+  const provider = new ethers.BrowserProvider(walletClient.transport);
+  return await provider.getSigner(walletClient.account.address);
+}
 
 // ------------------ CONFIG ------------------
 const AMOY = {


### PR DESCRIPTION
## Summary
- replace usage of `viem/ethers` with local utility `walletClientToSigner`
- avoid build-time failure due to missing `viem/ethers` export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68af0efaad4483338333195313b18660