### PR TITLE
docs: explain WalletConnect project id setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,16 @@ This project uses React and Vite.
    ```bash
    npm install
    ```
-2. Create a `.env` file based on `.env.example` and add your WalletConnect Cloud project ID:
+2. Create a `.env` file based on `.env.example` and set up a WalletConnect Cloud project ID:
    ```bash
    cp .env.example .env
-   # edit .env and set VITE_WALLETCONNECT_PROJECT_ID
    ```
+   You'll need to create an account on [WalletConnect Cloud](https://cloud.walletconnect.com/) to obtain a **projectId**.
+   Add it to your `.env` file:
+   ```bash
+   VITE_WALLETCONNECT_PROJECT_ID=<tu_project_id>
+   ```
+   Using the placeholder value `demo` will cause WalletConnect to return 403 responses.
    Without this value the app will still load but WalletConnect features
    will be disabled and a warning will appear at startup.
 


### PR DESCRIPTION
## Summary
- advise registering in WalletConnect Cloud to get a valid projectId
- document `.env` example and warn that using `demo` causes 403 errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden fetching @rainbow-me/rainbowkit)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af1a71b33c8333a121c74e582d7d5b