### PR TITLE
Use getDefaultConfig directly for Wagmi

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,7 +5,7 @@ import App from "./App.jsx";
 import "./index.css";
 import "@rainbow-me/rainbowkit/styles.css";
 
-import { WagmiProvider, createConfig, http } from "wagmi";
+import { WagmiProvider, http } from "wagmi";
 import { polygonAmoy } from "wagmi/chains";
 import {
   RainbowKitProvider,
@@ -23,16 +23,14 @@ if (!projectId) {
   );
 }
 
-const config = createConfig(
-  getDefaultConfig({
-    appName: "GroupDAO",
-    projectId: projectId || "demo",
-    chains: [polygonAmoy],
-    transports: {
-      [polygonAmoy.id]: http(),
-    },
-  }),
-);
+const config = getDefaultConfig({
+  appName: "GroupDAO",
+  projectId: projectId || "demo",
+  chains: [polygonAmoy],
+  transports: {
+    [polygonAmoy.id]: http(),
+  },
+});
 
 const queryClient = new QueryClient();
 


### PR DESCRIPTION
## Summary
- Remove redundant `createConfig` usage and import
- Configure Wagmi using `getDefaultConfig` directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68af1a7877608333b6055dfb2ffaada9