### PR TITLE
feat: implement email passkey login

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "wagmi": "^2.0.0",
     "viem": "^2.0.0",
     "@rainbow-me/rainbowkit": "^2.0.0",
-    "@tanstack/react-query": "^5.0.0"
+    "@tanstack/react-query": "^5.0.0",
+    "@privy-io/react-auth": "^1.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import ProposalList from "./ProposalList";
 import ThemeSwitcher from "./components/ThemeSwitcher";
 import { useAccount, useWalletClient } from "wagmi";
 import { ConnectButton, useConnectModal } from "@rainbow-me/rainbowkit";
+import { usePrivy, useWallets } from "@privy-io/react-auth";
 
 // Utility to bridge a viem wallet client to an ethers Signer
 async function walletClientToSigner(walletClient) {
@@ -1406,10 +1407,27 @@ export default function App() {
 
   const isBusy = (k) => !!busy[k];
 
-  const handleEmailLogin = useCallback(() => {
-    // TODO: Integrar proveedor de wallet embebida (Web3Auth, Privy, Magic, etc.)
-    toast.info("Login con email/passkey no implementado");
-  }, []);
+  const { login } = usePrivy();
+  const { wallets } = useWallets();
+
+  const handlePrivyLogin = useCallback(async () => {
+    try {
+      await login({ loginMethods: ["email"], createPrivyWallet: true });
+      const embedded = wallets.find((w) => w.type === "embedded");
+      if (embedded) {
+        const provider = await embedded.getEthereumProvider();
+        const ethersProvider = new ethers.BrowserProvider(provider);
+        const signer = await ethersProvider.getSigner();
+        const _contract = new ethers.Contract(CONTRACT_ADDRESS, ABI, signer);
+        setAccount(await signer.getAddress());
+        setContract(_contract);
+        toast.success("Sesión iniciada con Privy");
+      }
+    } catch (e) {
+      console.error("Error en login con Privy", e);
+      toast.error("Error al iniciar sesión con Privy");
+    }
+  }, [login, wallets]);
 
   const run = useCallback(async (key, fn) => {
     setBusy((s) => ({ ...s, [key]: true }));
@@ -1826,7 +1844,7 @@ export default function App() {
                 </button>
               )}
               <button
-                onClick={handleEmailLogin}
+                onClick={handlePrivyLogin}
                 className="px-3 py-2 rounded-xl border flex items-center gap-1 text-sm"
               >
                 Entrar con email/passkey

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,6 +12,7 @@ import {
   getDefaultConfig,
 } from "@rainbow-me/rainbowkit";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { PrivyProvider } from "@privy-io/react-auth";
 
 const projectId = import.meta.env.VITE_WALLETCONNECT_PROJECT_ID;
 
@@ -33,17 +34,20 @@ const config = getDefaultConfig({
 });
 
 const queryClient = new QueryClient();
+const privyAppId = import.meta.env.VITE_PRIVY_APP_ID;
 
 ReactDOM.createRoot(document.getElementById("root")).render(
   <React.StrictMode>
     <BrowserRouter basename="/DAOMonte">
-      <WagmiProvider config={config}>
-        <QueryClientProvider client={queryClient}>
-          <RainbowKitProvider>
-            <App />
-          </RainbowKitProvider>
-        </QueryClientProvider>
-      </WagmiProvider>
+      <PrivyProvider appId={privyAppId}>
+        <WagmiProvider config={config}>
+          <QueryClientProvider client={queryClient}>
+            <RainbowKitProvider>
+              <App />
+            </RainbowKitProvider>
+          </QueryClientProvider>
+        </WagmiProvider>
+      </PrivyProvider>
     </BrowserRouter>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## Summary
- integrate Privy for email/passkey login

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68af738589bc833398f8d504d28063d8